### PR TITLE
JSR310 Date and Time API support in json

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,6 +245,11 @@
       <version>2.3.1</version>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <version>2.3.1</version>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.7.6</version>

--- a/src/main/java/net/codestory/http/convert/TypeConvert.java
+++ b/src/main/java/net/codestory/http/convert/TypeConvert.java
@@ -15,18 +15,23 @@
  */
 package net.codestory.http.convert;
 
-import java.io.*;
-import java.util.*;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JSR310Module;
+import net.codestory.http.internal.Context;
 
-import net.codestory.http.internal.*;
-
-import com.fasterxml.jackson.annotation.*;
-import com.fasterxml.jackson.core.*;
-import com.fasterxml.jackson.databind.*;
+import java.io.IOException;
+import java.util.Map;
 
 public class TypeConvert {
   private static ObjectMapper OBJECT_MAPPER = new ObjectMapper()
       .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
+      .registerModule(new JSR310Module())
+      .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
       .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
   private TypeConvert() {

--- a/src/test/java/net/codestory/http/convert/TypeConvertTest.java
+++ b/src/test/java/net/codestory/http/convert/TypeConvertTest.java
@@ -15,11 +15,13 @@
  */
 package net.codestory.http.convert;
 
-import static org.assertj.core.api.Assertions.*;
+import org.junit.Test;
 
-import java.util.*;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
 
-import org.junit.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TypeConvertTest {
   @Test
@@ -68,14 +70,16 @@ public class TypeConvertTest {
 
   @Test
   public void json_to_bean() {
-    Human human = TypeConvert.fromJson("{\"name\":\"jack\",\"age\":31}", Human.class);
+    Human human = TypeConvert.fromJson("{\"name\":\"jack\",\"age\":31,\"birthDate\":\"1980-01-01\"}", Human.class);
 
     assertThat(human.name).isEqualTo("jack");
     assertThat(human.age).isEqualTo(31);
+    assertThat(human.birthDate).isEqualTo(LocalDate.parse("1980-01-01"));
   }
 
   static class Human {
     String name;
     int age;
+    LocalDate birthDate;
   }
 }


### PR DESCRIPTION
The new date and time types were crashing the Jackson serialization, the fix is pretty easy using the adequate Jackson module.
