### PR TITLE
Fix server-sent event handling for multiline event data

### DIFF
--- a/src/main/java/net/codestory/http/payload/PayloadWriter.java
+++ b/src/main/java/net/codestory/http/payload/PayloadWriter.java
@@ -145,11 +145,18 @@ public class PayloadWriter {
         stream.forEach(item -> {
           String json = (item instanceof String) ? (String) item : TypeConvert.toJson(item);
 
-          printStream
-            .append("data: ")
-            .append(json)
-            .append("\n\n")
-            .flush();
+          BufferedReader reader = new BufferedReader(new StringReader(json));
+          try {
+            for (String line = reader.readLine(); line != null; line = reader.readLine()) {
+              printStream
+                .append("data: ")
+                .append(line)
+                .append("\n");
+            }
+            printStream.append("\n").flush();
+          } catch (IOException e) {
+              throw new IllegalStateException("Unable to stream", e);
+          }
         });
         close();
       });

--- a/src/test/java/net/codestory/http/StreamTest.java
+++ b/src/test/java/net/codestory/http/StreamTest.java
@@ -38,6 +38,16 @@ public class StreamTest extends AbstractProdWebServerTest {
   }
 
   @Test
+  public void server_sent_events_multiline() {
+    AtomicLong index = new AtomicLong(0);
+    Supplier<String> messageSupplier = () -> "MESSAGE\n" + index.incrementAndGet();
+
+    server.configure(routes -> routes.get("/events", () -> Stream.generate(messageSupplier).limit(1000)));
+
+    get("/events").produces("data: MESSAGE\ndata: 1\n\n" + "data: MESSAGE\ndata: 2\n\n" + "data: MESSAGE\ndata: 3\n\n");
+    }
+
+  @Test
   public void stream() {
     byte[] buffer = "Hello World".getBytes(UTF_8);
 


### PR DESCRIPTION
When using the server-sent event feature, if the event string contains a line terminator character, only the first line is received by the client. When the event contains multiple lines, every line should start with `data:`.
