### PR TITLE
add the possibility to auto discover resource classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -298,6 +298,11 @@
       <artifactId>coffee-script</artifactId>
       <version>1.8.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+      <version>0.9.9</version>
+    </dependency>
 
     <!-- Optional dependencies -->
     <dependency>

--- a/src/mainjava/net/codestory/http/logs/Logs.java
+++ b/src/mainjava/net/codestory/http/logs/Logs.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (C) 2013-2014 all@code-story.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package net.codestory.http.logs;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.Collection;
+
+import static net.codestory.http.io.Strings.*;
+
+public class Logs {
+  private static final LogsImplementation LOG = Boolean.getBoolean("PROD_MODE") ? new Slf4jLogs() : new ConsoleLogs();
+
+  private Logs() {
+    // static class
+  }
+
+  public static void unableToBindServer(Exception e) {
+    LOG.error("Unable to bind server", e);
+  }
+
+  public static void mode(boolean production) {
+    LOG.info(production ? "Production mode" : "Dev mode. Start with -DPROD_MODE=true to run in production mode.");
+  }
+
+  public static void started(int port) {
+    LOG.info("Server started on port {}", port);
+  }
+
+  public static void compilerError(Throwable e) {
+    LOG.error(e.getMessage());
+  }
+
+  public static void unexpectedError(Throwable e) {
+    LOG.error(e.getMessage());
+  }
+
+  public static void unableToServeErrorPage(Exception e) {
+    LOG.error("Unable to serve an error page", e);
+  }
+
+  public static void cachingOnDisk(File path) {
+    LOG.info("Caching on disk @ {}", path.getAbsolutePath());
+  }
+
+  public static void uri(String uri) {
+    LOG.info(uri);
+  }
+
+  public static void reloadingConfiguration() {
+    LOG.info("Reloading configuration...");
+  }
+
+  public static void printKnownWebjars(Collection<String> uris, String extension) {
+    LOG.error("Found these webjars files with extension: " + extension);
+    for (String uri : uris) {
+      LOG.error(" + " + substringAfter(uri, "META-INF/resources"));
+    }
+  }
+
+  public static void printUnknownWebjar(String uri, String extension) {
+    LOG.error("Unable to find this webjar file: " + uri);
+    LOG.error("And no webjar file has extension [" + extension + "]");
+  }
+
+  public static void unableToConfigureRoutes(Throwable e) {
+    LOG.error("Unable to configure routes properly", e);
+  }
+
+  private static interface LogsImplementation {
+    void info(String message);
+
+    void info(String message, Object argument);
+
+    void error(String message);
+
+    void error(String message, Throwable e);
+  }
+
+  private static class ConsoleLogs implements LogsImplementation {
+    @Override
+    public void info(String message) {
+      System.out.println(message);
+    }
+
+    @Override
+    public void info(String message, Object argument) {
+      System.out.println(message.replace("{}", argument.toString()));
+    }
+
+    @Override
+    public void error(String message) {
+      System.err.println(message);
+    }
+
+    @Override
+    public void error(String message, Throwable e) {
+      System.err.println(message);
+      e.printStackTrace();
+    }
+  }
+
+  private static class Slf4jLogs implements LogsImplementation {
+    private static final Logger LOG = LoggerFactory.getLogger("Fluent");
+
+    @Override
+    public void info(String message) {
+      LOG.info(message);
+    }
+
+    @Override
+    public void info(String message, Object argument) {
+      LOG.info(message, argument);
+    }
+
+    @Override
+    public void error(String message) {
+      LOG.error(message);
+    }
+
+    @Override
+    public void error(String message, Throwable e) {
+      LOG.error(message, e);
+    }
+  }
+}

--- a/src/main/java/net/codestory/http/annotations/Resource.java
+++ b/src/main/java/net/codestory/http/annotations/Resource.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2013-2014 all@code-story.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package net.codestory.http.annotations;
+
+import java.lang.annotation.*;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Target(TYPE)
+@Retention(RUNTIME)
+public @interface Resource {
+}

--- a/src/main/java/net/codestory/http/errors/ErrorPage.java
+++ b/src/main/java/net/codestory/http/errors/ErrorPage.java
@@ -15,18 +15,18 @@
  */
 package net.codestory.http.errors;
 
-import static net.codestory.http.constants.HttpStatus.*;
+import net.codestory.http.payload.Payload;
+import net.codestory.http.templating.ModelAndView;
 
 import java.io.*;
 
-import net.codestory.http.payload.*;
-import net.codestory.http.templating.*;
+import static net.codestory.http.constants.HttpStatus.*;
 
 public class ErrorPage {
   private final Payload payload;
-  private final Exception exception;
+  private final Throwable exception;
 
-  public ErrorPage(Payload payload, Exception exception) {
+  public ErrorPage(Payload payload, Throwable exception) {
     this.payload = payload;
     this.exception = exception;
   }
@@ -44,7 +44,7 @@ public class ErrorPage {
     return (payload.code() == NOT_FOUND) ? "404.html" : "500.html";
   }
 
-  private static String toString(Exception error) {
+  private static String toString(Throwable error) {
     if (error == null) {
       return "";
     }

--- a/src/main/java/net/codestory/http/internal/SimpleResponse.java
+++ b/src/main/java/net/codestory/http/internal/SimpleResponse.java
@@ -15,14 +15,15 @@
  */
 package net.codestory.http.internal;
 
-import java.io.*;
-import java.text.*;
-import java.util.*;
-
 import net.codestory.http.Cookie;
 import net.codestory.http.Response;
+import org.simpleframework.http.Status;
 
-import org.simpleframework.http.*;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.*;
 
 class SimpleResponse implements Response {
   private final org.simpleframework.http.Response response;

--- a/src/main/java/net/codestory/http/payload/PayloadWriter.java
+++ b/src/main/java/net/codestory/http/payload/PayloadWriter.java
@@ -15,6 +15,26 @@
  */
 package net.codestory.http.payload;
 
+import net.codestory.http.Request;
+import net.codestory.http.Response;
+import net.codestory.http.compilers.*;
+import net.codestory.http.convert.TypeConvert;
+import net.codestory.http.io.InputStreams;
+import net.codestory.http.io.Resources;
+import net.codestory.http.misc.*;
+import net.codestory.http.templating.*;
+import net.codestory.http.types.ContentTypes;
+
+import java.io.*;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Stream;
+import java.util.zip.GZIPOutputStream;
+
 import static java.nio.charset.StandardCharsets.*;
 import static java.util.Objects.*;
 import static net.codestory.http.constants.Encodings.*;
@@ -22,21 +42,6 @@ import static net.codestory.http.constants.Headers.*;
 import static net.codestory.http.constants.HttpStatus.*;
 import static net.codestory.http.constants.Methods.*;
 import static net.codestory.http.io.Strings.*;
-
-import java.io.*;
-import java.net.URL;
-import java.nio.file.*;
-import java.util.*;
-import java.util.stream.*;
-import java.util.zip.*;
-
-import net.codestory.http.*;
-import net.codestory.http.compilers.*;
-import net.codestory.http.convert.*;
-import net.codestory.http.io.*;
-import net.codestory.http.misc.*;
-import net.codestory.http.templating.*;
-import net.codestory.http.types.*;
 
 public class PayloadWriter {
   protected final Request request;
@@ -55,11 +60,34 @@ public class PayloadWriter {
     this.compilers = compilers;
   }
 
-  public void writeAndClose(Payload payload) throws IOException {
+  public CompletionStage writeAndClose(Payload payload) throws IOException {
+    if(isAsync(payload)) {
+      return writeAndCloseAsync(payload);
+    }
+    return writeAndCloseSync(payload);
+  }
+
+  private CompletableFuture writeAndCloseAsync(Payload payload) {
+    CompletableFuture<?> future = (CompletableFuture<?>) payload.rawContent();
+    return future.thenAccept(content -> {
+      try {
+        writeAndClose(new Payload(content));
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
+  private CompletableFuture writeAndCloseSync(Payload payload) throws IOException {
     write(payload);
     if (!isStream(payload.rawContent())) {
       close();
     }
+    return CompletableFuture.completedFuture(null);
+  }
+
+  private boolean isAsync(Payload payload) {
+    return payload.rawContent() instanceof CompletableFuture<?>;
   }
 
   protected void close() {
@@ -71,6 +99,7 @@ public class PayloadWriter {
   }
 
   protected void write(Payload payload) throws IOException {
+
     response.setHeaders(payload.headers());
     response.setCookies(payload.cookies());
 

--- a/src/main/java/net/codestory/http/routes/RouteCollection.java
+++ b/src/main/java/net/codestory/http/routes/RouteCollection.java
@@ -19,6 +19,7 @@ import net.codestory.http.Configuration;
 import net.codestory.http.Context;
 import net.codestory.http.Request;
 import net.codestory.http.Response;
+import net.codestory.http.annotations.Resource;
 import net.codestory.http.compilers.CompilerFacade;
 import net.codestory.http.convert.TypeConvert;
 import net.codestory.http.extensions.Extensions;
@@ -34,10 +35,13 @@ import net.codestory.http.payload.Payload;
 import net.codestory.http.payload.PayloadWriter;
 import net.codestory.http.templating.Site;
 import net.codestory.http.websockets.*;
+import org.reflections.Reflections;
+import org.reflections.scanners.TypeAnnotationsScanner;
+import org.reflections.util.ClasspathHelper;
+import org.reflections.util.ConfigurationBuilder;
 
 import java.lang.reflect.Method;
-import java.util.Deque;
-import java.util.LinkedList;
+import java.util.*;
 import java.util.function.Supplier;
 
 import static net.codestory.http.annotations.AnnotationHelper.parseAnnotations;
@@ -456,6 +460,15 @@ public class RouteCollection implements Routes {
   @Override
   public RoutesWithPattern url(String uriPattern) {
     return new RoutesWithPattern(this, uriPattern);
+  }
+
+  @Override
+  public void autoDiscover(String packageToScan) {
+    final Reflections reflections = new Reflections(new ConfigurationBuilder()
+      .setUrls(ClasspathHelper.forPackage(packageToScan))
+      .addScanners(new TypeAnnotationsScanner()));
+    final Set<Class<?>> resources = reflections.getTypesAnnotatedWith(Resource.class);
+    resources.forEach(this::add);
   }
 
   protected RouteCollection add(String method, String uriPattern, AnyRoute route) {

--- a/src/main/java/net/codestory/http/routes/Routes.java
+++ b/src/main/java/net/codestory/http/routes/Routes.java
@@ -15,12 +15,12 @@
  */
 package net.codestory.http.routes;
 
-import java.io.*;
-
 import net.codestory.http.extensions.Extensions;
-import net.codestory.http.filters.*;
-import net.codestory.http.injection.*;
-import net.codestory.http.websockets.*;
+import net.codestory.http.filters.Filter;
+import net.codestory.http.injection.IocAdapter;
+import net.codestory.http.websockets.WebSocketListenerFactory;
+
+import java.io.Serializable;
 
 public interface Routes extends Serializable {
   Routes setExtensions(Extensions extensions);
@@ -134,4 +134,6 @@ public interface Routes extends Serializable {
   Routes delete(String uriPattern, FourParamsRoute route);
 
   RoutesWithPattern url(String uriPattern);
+
+  void autoDiscover(String packageToSCan);
 }

--- a/src/test/java/net/codestory/http/AsyncResponseTest.java
+++ b/src/test/java/net/codestory/http/AsyncResponseTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2013-2014 all@code-story.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package net.codestory.http;
+
+import net.codestory.http.testhelpers.AbstractProdWebServerTest;
+import org.junit.Test;
+
+import java.util.concurrent.*;
+
+public class AsyncResponseTest extends AbstractProdWebServerTest {
+
+  ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+  @Test
+  public void waits_for_completion() {
+    final CompletableFuture<String> future = CompletableFuture.supplyAsync(() -> "test", executorService);
+    configure(routes -> routes.get("/", context -> future));
+
+    get("/").should().respond(200).contain("test");
+  }
+
+  @Test
+  public void uses_expected_converters() {
+    final CompletableFuture<Pojo> future = CompletableFuture.supplyAsync(() -> new Pojo("coucou"), executorService);
+    configure(routes -> routes.get("/", context -> future));
+
+    get("/").should().respond(200).haveType("application/json").contain("{\"name\":\"coucou\"}");
+  }
+
+  @Test
+  public void deals_with_error() throws InterruptedException {
+    final CompletableFuture<Object> future = CompletableFuture.supplyAsync(() -> {
+      throw new RuntimeException("plop");
+    }, executorService);
+
+    configure(routes -> routes.get("/", context -> future));
+
+    get("/").should().respond(500);
+  }
+
+  public static class Pojo {
+    public Pojo(String name) {
+      this.name = name;
+    }
+
+    public String name;
+  }
+}

--- a/src/test/java/net/codestory/http/routes/RouteCollectionTest.java
+++ b/src/test/java/net/codestory/http/routes/RouteCollectionTest.java
@@ -15,12 +15,15 @@
  */
 package net.codestory.http.routes;
 
-import static org.mockito.Mockito.*;
-
+import net.codestory.http.annotations.Get;
+import net.codestory.http.annotations.Resource;
 import net.codestory.http.misc.Env;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
-import org.junit.*;
-import org.junit.rules.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 public class RouteCollectionTest {
   RouteCollection routeCollection = new RouteCollection(mock(Env.class));
@@ -42,5 +45,26 @@ public class RouteCollectionTest {
     thrown.expectMessage("Expected 2 parameters in /:one/:two/:three");
 
     routeCollection.get("/:one/:two/:three", (context, one, two) -> "");
+  }
+
+  @Test
+  public void scan_annoted_resource() {
+    routeCollection.autoDiscover("net.codestory.http");
+
+    assertThat(routeCollection.routes.getSortedRoutes()).hasSize(1);
+    assertThat(routeCollection.routes.getSortedRoutes()[0].matchMethod("GET")).isTrue();
+    assertThat(routeCollection.routes.getSortedRoutes()[0].matchUri("/test")).isTrue();
+
+  }
+
+  @SuppressWarnings("UnusedDeclaration")
+  @Resource
+  public static class StubResource {
+
+    @Get("/test")
+    public String get() {
+      return "hello";
+    }
+
   }
 }


### PR DESCRIPTION
It's just a very simple proposition to let fluent-http auto discover resource classes. 
I added an "autoDiscover" method to RouteCollection, and I used https://github.com/ronmamo/reflections to deal with scanning. It's yet another dependency to pull, so maybe it would be better to do it manually. 
I'm not very proud of my test either. 