### PR TITLE
returning a CompletableFuture from resource

### DIFF
--- a/src/main/java/net/codestory/http/errors/ErrorPage.java
+++ b/src/main/java/net/codestory/http/errors/ErrorPage.java
@@ -15,18 +15,18 @@
  */
 package net.codestory.http.errors;
 
-import static net.codestory.http.constants.HttpStatus.*;
+import net.codestory.http.payload.Payload;
+import net.codestory.http.templating.ModelAndView;
 
 import java.io.*;
 
-import net.codestory.http.payload.*;
-import net.codestory.http.templating.*;
+import static net.codestory.http.constants.HttpStatus.*;
 
 public class ErrorPage {
   private final Payload payload;
-  private final Exception exception;
+  private final Throwable exception;
 
-  public ErrorPage(Payload payload, Exception exception) {
+  public ErrorPage(Payload payload, Throwable exception) {
     this.payload = payload;
     this.exception = exception;
   }
@@ -44,7 +44,7 @@ public class ErrorPage {
     return (payload.code() == NOT_FOUND) ? "404.html" : "500.html";
   }
 
-  private static String toString(Exception error) {
+  private static String toString(Throwable error) {
     if (error == null) {
       return "";
     }

--- a/src/main/java/net/codestory/http/internal/SimpleResponse.java
+++ b/src/main/java/net/codestory/http/internal/SimpleResponse.java
@@ -15,14 +15,15 @@
  */
 package net.codestory.http.internal;
 
-import java.io.*;
-import java.text.*;
-import java.util.*;
-
 import net.codestory.http.Cookie;
 import net.codestory.http.Response;
+import org.simpleframework.http.Status;
 
-import org.simpleframework.http.*;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.*;
 
 class SimpleResponse implements Response {
   private final org.simpleframework.http.Response response;

--- a/src/main/java/net/codestory/http/logs/Logs.java
+++ b/src/main/java/net/codestory/http/logs/Logs.java
@@ -15,12 +15,13 @@
  */
 package net.codestory.http.logs;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.Collection;
+
 import static net.codestory.http.io.Strings.*;
-
-import java.io.*;
-import java.util.*;
-
-import org.slf4j.*;
 
 public class Logs {
   private static final LogsImplementation LOG = Boolean.getBoolean("PROD_MODE") ? new Slf4jLogs() : new ConsoleLogs();
@@ -41,15 +42,15 @@ public class Logs {
     LOG.info("Server started on port {}", port);
   }
 
-  public static void compilerError(Exception e) {
+  public static void compilerError(Throwable e) {
     LOG.error(e.getMessage());
   }
 
-  public static void unexpectedError(Exception e) {
+  public static void unexpectedError(Throwable e) {
     LOG.error(e.getMessage());
   }
 
-  public static void unableToServeErrorPage(Exception e) {
+  public static void unableToServeErrorPage(Throwable e) {
     LOG.error("Unable to serve an error page", e);
   }
 

--- a/src/main/java/net/codestory/http/payload/Payload.java
+++ b/src/main/java/net/codestory/http/payload/Payload.java
@@ -15,14 +15,14 @@
  */
 package net.codestory.http.payload;
 
-import static net.codestory.http.constants.Headers.*;
-import static net.codestory.http.constants.HttpStatus.*;
+import net.codestory.http.*;
+import net.codestory.http.convert.*;
 
 import java.net.*;
 import java.util.*;
 
-import net.codestory.http.*;
-import net.codestory.http.convert.*;
+import static net.codestory.http.constants.Headers.*;
+import static net.codestory.http.constants.HttpStatus.*;
 
 public class Payload {
   private final String contentType;

--- a/src/test/java/net/codestory/http/AsyncResponseTest.java
+++ b/src/test/java/net/codestory/http/AsyncResponseTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2013-2014 all@code-story.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package net.codestory.http;
+
+import net.codestory.http.testhelpers.AbstractProdWebServerTest;
+import org.junit.Test;
+
+import java.util.concurrent.*;
+
+public class AsyncResponseTest extends AbstractProdWebServerTest {
+
+  ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+  @Test
+  public void waits_for_completion() {
+    final CompletableFuture<String> future = CompletableFuture.supplyAsync(() -> "test", executorService);
+    configure(routes -> routes.get("/", context -> future));
+
+    get("/").should().respond(200).contain("test");
+  }
+
+  @Test
+  public void uses_expected_converters() {
+    final CompletableFuture<Pojo> future = CompletableFuture.supplyAsync(() -> new Pojo("coucou"), executorService);
+    configure(routes -> routes.get("/", context -> future));
+
+    get("/").should().respond(200).haveType("application/json").contain("{\"name\":\"coucou\"}");
+  }
+
+  @Test
+  public void deals_with_error() throws InterruptedException {
+    final CompletableFuture<Object> future = CompletableFuture.supplyAsync(() -> {
+      throw new RuntimeException("plop");
+    }, executorService);
+
+    configure(routes -> routes.get("/", context -> future));
+
+    get("/").should().respond(500);
+  }
+
+  public static class Pojo {
+    public Pojo(String name) {
+      this.name = name;
+    }
+
+    public String name;
+  }
+}


### PR DESCRIPTION
If a resource returns a completable future, fluent will not block the web thread waiting for completion.  Could be usefull when you do some async computation (as we do here :) )