### PR TITLE
Fixed classpathScanner on windows with signature change 

### DIFF
--- a/src/main/java/net/codestory/http/io/ClasspathScanner.java
+++ b/src/main/java/net/codestory/http/io/ClasspathScanner.java
@@ -25,9 +25,7 @@ import java.util.function.Predicate;
 import static net.codestory.http.io.Strings.substringBeforeLast;
 
 public class ClasspathScanner {
-  public Set<String> getResources(Path root) {
-    String prefix = root.toString();
-
+  public Set<String> getResources(String prefix) {
     return listPaths(prefix, path -> !path.endsWith(".class"));
   }
 

--- a/src/main/java/net/codestory/http/routes/WebJarsRoute.java
+++ b/src/main/java/net/codestory/http/routes/WebJarsRoute.java
@@ -64,7 +64,7 @@ class WebJarsRoute implements Route {
     String extension = extension(wantedUri);
 
     List<String> filteredUris = new ClasspathScanner()
-      .getResources(Paths.get(WEBJARS_PATH_PREFIX))
+      .getResources(WEBJARS_PATH_PREFIX)
       .stream()
       .filter(uri -> uri.endsWith(extension))
       .collect(toList());

--- a/src/main/java/net/codestory/http/templating/Site.java
+++ b/src/main/java/net/codestory/http/templating/Site.java
@@ -84,7 +84,7 @@ public class Site {
     try {
       if (env.classPath()) {
         Path rootPath = Paths.get(env.appFolder());
-        new ClasspathScanner().getResources(rootPath).forEach(resource -> paths.add(relativePath(rootPath, Paths.get(resource))));
+        new ClasspathScanner().getResources(env.appFolder()).forEach(resource -> paths.add(relativePath(rootPath, Paths.get(resource))));
       }
 
       if (env.filesystem()) {

--- a/src/test/java/net/codestory/http/io/ClasspathScannerTest.java
+++ b/src/test/java/net/codestory/http/io/ClasspathScannerTest.java
@@ -27,7 +27,7 @@ public class ClasspathScannerTest {
 
   @Test
   public void scan_main_resources() {
-    Set<String> resources = classpathScanner.getResources(Paths.get("app"));
+    Set<String> resources = classpathScanner.getResources("app");
 
     assertThat(resources)
       .contains("app/404.html")
@@ -37,7 +37,7 @@ public class ClasspathScannerTest {
 
   @Test
   public void scan_test_resources() {
-    Set<String> resources = classpathScanner.getResources(Paths.get("app"));
+    Set<String> resources = classpathScanner.getResources("app");
 
     assertThat(resources)
       .contains("app/0variable.txt")
@@ -47,7 +47,7 @@ public class ClasspathScannerTest {
 
   @Test
   public void scan_webjars() {
-    Set<String> resources = classpathScanner.getResources(Paths.get("META-INF/resources/webjars/"));
+    Set<String> resources = classpathScanner.getResources("META-INF/resources/webjars/");
 
     assertThat(resources)
       .contains("META-INF/resources/webjars/fakewebjar/1.0/fake.js")


### PR DESCRIPTION
Changed getResources signature to take a String in place of a Path.
ClasspathScanner uses URL and not the FS, so it doesn't need Path object.
