### PR TITLE
Parametrize web server nb threads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .idea/
 *.iml
+*.iws
+*.ipr
 target/
 pom.xml.releaseBackup
 release.properties

--- a/src/main/java/net/codestory/http/AbstractWebServer.java
+++ b/src/main/java/net/codestory/http/AbstractWebServer.java
@@ -43,12 +43,13 @@ public abstract class AbstractWebServer<T extends AbstractWebServer<T>> {
   protected RoutesProvider routesProvider;
   protected int port = -1;
 
-  protected AbstractWebServer() {
-    this.server = createHttpServer(this::handleHttp, this::handleWebSocket);
+  protected AbstractWebServer(int count, int select, int websocketThreads) {
+    this.server = createHttpServer(this::handleHttp, this::handleWebSocket, count, select, websocketThreads);
     this.env = createEnv();
   }
 
-  protected abstract HttpServerWrapper createHttpServer(Handler httpHandler, WebSocketHandler webSocketHandler);
+  protected abstract HttpServerWrapper createHttpServer(Handler httpHandler, WebSocketHandler webSocketHandler,
+                                                        int count, int select, int websocketThreads);
 
   protected Env createEnv() {
     return new Env();

--- a/src/main/java/net/codestory/http/WebServer.java
+++ b/src/main/java/net/codestory/http/WebServer.java
@@ -26,8 +26,26 @@ public class WebServer extends AbstractWebServer<WebServer> {
       .start();
   }
 
+  private static final int DEFAULT_SELECT_THREADS = 1;
+  private static final int DEFAULT_COUNT_THREADS = 8;
+  private static final int DEFAULT_WEBSOCKET_THREADS = 10;
+
+  public WebServer() {
+    this(DEFAULT_SELECT_THREADS, DEFAULT_COUNT_THREADS, DEFAULT_WEBSOCKET_THREADS);
+  }
+
+  /**
+   * @param countThreads     the number of threads used for each pool (default is 8)
+   * @param selectThreads    the number of selector threads to use (default is 1)
+   * @param websocketThreads the number of threads to use in router selecter (default is 10)
+   */
+  public WebServer(int countThreads, int selectThreads, int websocketThreads) {
+    super(countThreads, selectThreads, websocketThreads);
+  }
+
   @Override
-  protected HttpServerWrapper createHttpServer(Handler httpHandler, WebSocketHandler webSocketHandler) {
-    return new SimpleServerWrapper(httpHandler, webSocketHandler);
+  protected HttpServerWrapper createHttpServer(Handler httpHandler, WebSocketHandler webSocketHandler,
+                                               int count, int select, int websocketThreads) {
+    return new SimpleServerWrapper(httpHandler, webSocketHandler, count, select, websocketThreads);
   }
 }

--- a/src/main/java/net/codestory/http/internal/SimpleServerWrapper.java
+++ b/src/main/java/net/codestory/http/internal/SimpleServerWrapper.java
@@ -35,9 +35,6 @@ import org.simpleframework.transport.connect.SocketConnection;
 import javax.net.ssl.SSLContext;
 
 public class SimpleServerWrapper implements HttpServerWrapper, Container, Service {
-  private static final int DEFAULT_SELECT_THREADS = 1;
-  private static final int DEFAULT_COUNT_THREADS = 8;
-  private static final int DEFAULT_WEBSOCKET_THREADS = 10;
 
   private final Handler httpHandler;
   private final WebSocketHandler webSocketHandler;
@@ -46,10 +43,6 @@ public class SimpleServerWrapper implements HttpServerWrapper, Container, Servic
   private final int webSocketThreads;
 
   private SocketConnection socketConnection;
-
-  public SimpleServerWrapper(Handler httpHandler, WebSocketHandler webSocketHandler) {
-    this(httpHandler, webSocketHandler, DEFAULT_COUNT_THREADS, DEFAULT_SELECT_THREADS, DEFAULT_WEBSOCKET_THREADS);
-  }
 
   public SimpleServerWrapper(Handler httpHandler, WebSocketHandler webSocketHandler, int count, int select, int webSocketThreads) {
     this.httpHandler = httpHandler;


### PR DESCRIPTION
When i tried apache bench on my service, I soon had that kind of logs:

````
[Worker: RequestDispatcher: Thread-7] [Fluent] - Could not get a resource from the pool
````
    
It would be great to document what values need to be changed depending on what  you want to do (`countThreads`, `selectThreads` and `websocketThreads`) with your server. As of now, I don't know what I need to chage to scale my service up.
