### PR TITLE
test with infinite stream

### DIFF
--- a/src/main/java/net/codestory/http/payload/PayloadWriter.java
+++ b/src/main/java/net/codestory/http/payload/PayloadWriter.java
@@ -232,15 +232,16 @@ public class PayloadWriter {
     PrintStream printStream = new PrintStream(response.outputStream());
 
     try (Stream<?> stream = (Stream<?>) payload.rawContent()) {
-      stream.forEach(item -> {
+      stream.map(item -> {
         String jsonOrPlainString = (item instanceof String) ? (String) item : TypeConvert.toJson(item);
 
         printStream
             .append("data: ")
             .append(jsonOrPlainString.replaceAll("[\n]", "\ndata: "))
-            .append("\n\n")
-            .flush();
-      });
+            .append("\n\n");
+        return printStream.checkError();
+      }).filter(ioExceptionHasOccurred -> ioExceptionHasOccurred)
+        .findFirst();
     }
   }
 


### PR DESCRIPTION
#129 looks like this use case :
 - produce an infinite stream on server side
 - close connection on client side

To mimic this use case in test, I have to set a read timeout on http client. This feature doesn't exists (yet / or never) on fluent-rest-test. That's why there is some direct call to `OkHttpClient`.

Here are some stacks on server side :

    org.simpleframework.transport.TransportException: Buffer has been closed
        at org.simpleframework.transport.SocketBuffer.flush(SocketBuffer.java:203)
        at org.simpleframework.transport.SocketFlusher.execute(SocketFlusher.java:101)
        at org.simpleframework.transport.FlushSignaller.run(FlushSignaller.java:100)
        at org.simpleframework.transport.reactor.ExecuteAction.run(ExecuteAction.java:72)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)

or

    org.simpleframework.http.core.BodyEncoderException: Stream has been closed
        at org.simpleframework.http.core.ChunkedEncoder.encode(ChunkedEncoder.java:150)
        at org.simpleframework.http.core.ResponseEncoder.write(ResponseEncoder.java:197)
        at org.simpleframework.http.core.ResponseEncoder.write(ResponseEncoder.java:179)
        at org.simpleframework.http.core.ResponseBuffer.write(ResponseBuffer.java:210)
        at org.simpleframework.http.core.ResponseBuffer.write(ResponseBuffer.java:181)
        at org.simpleframework.http.core.ResponseBuffer.write(ResponseBuffer.java:160)
        at java.io.PrintStream.write(PrintStream.java:480)
        at sun.nio.cs.StreamEncoder.writeBytes(StreamEncoder.java:221)
        at sun.nio.cs.StreamEncoder.implFlushBuffer(StreamEncoder.java:291)
        at sun.nio.cs.StreamEncoder.flushBuffer(StreamEncoder.java:104)
        at java.io.OutputStreamWriter.flushBuffer(OutputStreamWriter.java:185)
        at java.io.PrintStream.write(PrintStream.java:527)
        at java.io.PrintStream.print(PrintStream.java:669)
        at java.io.PrintStream.append(PrintStream.java:1065)
        at net.codestory.http.payload.PayloadWriter.lambda$writeEventStream$39(PayloadWriter.java:239)
        at net.codestory.http.payload.PayloadWriter$$Lambda$72/1573356086.accept(Unknown Source)
        at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:184)
        at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
        at java.util.Iterator.forEachRemaining(Iterator.java:116)
        at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:512)
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:502)
        at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
        at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:418)
        at net.codestory.http.payload.PayloadWriter.writeEventStream(PayloadWriter.java:235)
        at net.codestory.http.payload.PayloadWriter.streamPayload(PayloadWriter.java:221)
        at net.codestory.http.payload.PayloadWriter.write(PayloadWriter.java:187)
        at net.codestory.http.payload.PayloadWriter.writeAndCloseSync(PayloadWriter.java:106)
        at net.codestory.http.payload.PayloadWriter.writeAndClose(PayloadWriter.java:95)
        at net.codestory.http.AbstractWebServer.handleHttp(AbstractWebServer.java:154)
        at net.codestory.http.AbstractWebServer$$Lambda$63/1003206025.handle(Unknown Source)
        at net.codestory.http.internal.SimpleServerWrapper.handle(SimpleServerWrapper.java:71)
        at org.simpleframework.http.socket.service.RouterContainer.handle(RouterContainer.java:106)
        at org.simpleframework.http.core.RequestDispatcher.dispatch(RequestDispatcher.java:121)
        at org.simpleframework.http.core.RequestDispatcher.run(RequestDispatcher.java:103)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)

The trick is to stop evaluating stream at first `IOException` (i.e. when connection is closed by remote client). Documentation of `PrintStream` enforce user to use `checkError()` instead of `try { } catch (IOException)` during writing - which ends up with a weird api.