### PR TITLE
Last parameter can match the end of uri

### DIFF
--- a/src/main/java/net/codestory/http/routes/UriParser.java
+++ b/src/main/java/net/codestory/http/routes/UriParser.java
@@ -15,10 +15,12 @@
  */
 package net.codestory.http.routes;
 
-import java.util.*;
+import net.codestory.http.Query;
+import net.codestory.http.io.Strings;
 
-import net.codestory.http.*;
-import net.codestory.http.io.*;
+import java.util.Objects;
+
+import static java.util.Arrays.asList;
 
 public class UriParser implements Comparable<UriParser> {
   private final String uriPattern;
@@ -39,13 +41,13 @@ public class UriParser implements Comparable<UriParser> {
 
   public String[] params(String uri, Query query) {
     String[] uriParts = parts(uri);
-
     String[] params = new String[paramsCount];
 
     int index = 0;
-    for (int i = 0; i < uriParts.length; i++) {
+    for (int i = 0; i < patternParts.length; i++) {
       if (patternParts[i].startsWith(":")) {
-        params[index++] = uriParts[i];
+        params[index++] = (i == patternParts.length - 1) ?
+          String.join("/", asList(uriParts).subList(i, uriParts.length)) : uriParts[i];
       }
     }
     for (int i = 0; i < queryParamsParts.length; i++) {
@@ -59,7 +61,7 @@ public class UriParser implements Comparable<UriParser> {
 
   public boolean matches(String uri) {
     String[] uriParts = parts(stripQueryParams(uri));
-    if (patternParts.length != uriParts.length) {
+    if (patternParts.length != uriParts.length && !endsWithParameter(uriPattern)) {
       return false;
     }
 
@@ -70,7 +72,11 @@ public class UriParser implements Comparable<UriParser> {
     }
 
     int lastPart = patternParts.length - 1;
-    return !(patternParts[lastPart].startsWith(":") && uriParts[lastPart].isEmpty());
+    return lastPart < uriParts.length && !(patternParts[lastPart].startsWith(":") && uriParts[lastPart].isEmpty());
+  }
+
+  private static boolean endsWithParameter(String uriPattern) {
+    return uriPattern.lastIndexOf("/") == uriPattern.lastIndexOf(":") - 1;
   }
 
   private static String[] parts(String uri) {

--- a/src/test/java/net/codestory/http/routes/RoutePrecedenceTest.java
+++ b/src/test/java/net/codestory/http/routes/RoutePrecedenceTest.java
@@ -80,14 +80,14 @@ public class RoutePrecedenceTest extends AbstractProdWebServerTest {
   @Test
   public void catch_all_is_always_last() {
     configure(routes -> routes
-        .get("/:param", (context, param) -> "One")
+        .get("/bar/:endparam", (context, param) -> "One")
         .get("/foo", "Two")
         .any((context) -> "last")
         .anyGet((context) -> "antepenultimate")
     );
 
     get("/foo").should().contain("Two");
-    get("/bar").should().contain("One");
+    get("/bar/baz").should().contain("One");
     get("/catch/all/get").should().contain("antepenultimate");
     post("/catch/all").should().contain("last");
     put("/catch/all").should().contain("last");

--- a/src/test/java/net/codestory/http/routes/UriParserTest.java
+++ b/src/test/java/net/codestory/http/routes/UriParserTest.java
@@ -103,6 +103,17 @@ public class UriParserTest {
     assertThat(new UriParser("/foo")).isLessThanOrEqualTo(new UriParser("/foo/bar/qix"));
   }
 
+  @Test
+  public void test_last_param_matches_end_uri() {
+    assertThat(new UriParser("/directory/:directory").matches("/directory/to/my/resource")).isTrue();
+    assertThat(new UriParser("/directory/:directory").params("/directory/to/my/resource", null)).containsExactly("to/my/resource");
+    assertThat(new UriParser("/with/:param/in/:url").params("/with/param/in/the/middle/of/url", null)).containsExactly("param", "the/middle/of/url");
+
+    assertThat(new UriParser("/end/:empty").matches("/end")).isFalse();
+    assertThat(new UriParser("/end/:empty").matches("/end/")).isFalse();
+    assertThat(new UriParser("/end/:empty").params("/end/", null)).containsExactly("");
+  }
+
   private static Query query(String key, String value) {
     Query query = mock(Query.class);
     when(query.get(key)).thenReturn(value);


### PR DESCRIPTION
I was wondering if this use case could be interesting for fluent-http. 

The idea is to match the end of the uri if there is a parameter at the end : `/directory/:directory` could match `/directory/to/my/resource` and `directory` parameter would be assigned with `to/my/resource`

I've seen this use case with S3 SDK [getObject()](https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/examples-s3-objects.html#download-object) where the url ends with the path of the object.

What do you think ?