### PR TITLE
feat: make env's appFolder configurable

### DIFF
--- a/src/main/java/net/codestory/http/misc/Env.java
+++ b/src/main/java/net/codestory/http/misc/Env.java
@@ -15,7 +15,6 @@
  */
 package net.codestory.http.misc;
 
-import com.google.common.annotations.VisibleForTesting;
 import net.codestory.http.reload.MasterFolderWatch;
 
 import java.io.File;
@@ -173,18 +172,13 @@ public class Env implements Serializable {
     return diskCache;
   }
 
-  @VisibleForTesting
-  private static String getenv(String envVar) {
-    return System.getenv(envVar);
-  }
-
   private static String get(String propertyName) {
-    String env = getenv(propertyName);
+    String env = System.getenv(propertyName);
     return (env != null) ? env : System.getProperty(propertyName);
   }
 
   private static String get(String propertyName, String defaultValue) {
-    String env = getenv(propertyName);
+    String env = System.getenv(propertyName);
     return (env != null) ? env : System.getProperty(propertyName, defaultValue);
   }
 

--- a/src/test/java/net/codestory/http/misc/EnvTest.java
+++ b/src/test/java/net/codestory/http/misc/EnvTest.java
@@ -128,6 +128,30 @@ public class EnvTest {
   }
 
   @Test
+  public void with_app_folder() {
+    Env env = Env.prod().withAppFolder("app/public");
+
+    assertThat(env.prodMode()).isTrue();
+    assertThat(env.classPath()).isTrue();
+    assertThat(env.filesystem()).isTrue();
+    assertThat(env.gzip()).isTrue();
+    assertThat(env.workingDir()).isEqualTo(new File("."));
+    assertThat(env.appFolder()).isEqualTo("app/public");
+    assertThat(env.injectLiveReloadScript()).isFalse();
+    assertThat(env.liveReloadServer()).isFalse();
+    assertThat(env.diskCache()).isTrue();
+  }
+
+  @Test
+  public void with_app_folder_system_property() {
+    System.setProperty("APP_FOLDER", "app/public");
+    Env env = new Env();
+    assertThat(env.appFolder()).isEqualTo("app/public");
+    // tear down system property
+    System.clearProperty("APP_FOLDER");
+  }
+
+  @Test
   public void injectLiveReloadScript() {
     Env env = Env.prod().withInjectLiveReloadScript(true);
 


### PR DESCRIPTION
The app folder is "app" by default. This PR adds the ability to change this using:

* a JVM property ;
* a environment varialble ;
* or a builder method `withAppFolder(...)`