### PR TITLE
fix: add correct content for "mjs" files

### DIFF
--- a/src/main/java/net/codestory/http/types/ContentTypes.java
+++ b/src/main/java/net/codestory/http/types/ContentTypes.java
@@ -54,6 +54,8 @@ public class ContentTypes {
       case ".less":
         return "text/css;charset=UTF-8";
       case ".js":
+      case ".mjs":
+      case ".cjs":
       case ".coffee":
       case ".litcoffee":
         return "application/javascript;charset=UTF-8";

--- a/src/main/java/net/codestory/http/types/ContentTypes.java
+++ b/src/main/java/net/codestory/http/types/ContentTypes.java
@@ -55,7 +55,6 @@ public class ContentTypes {
         return "text/css;charset=UTF-8";
       case ".js":
       case ".mjs":
-      case ".cjs":
       case ".coffee":
       case ".litcoffee":
         return "application/javascript;charset=UTF-8";

--- a/src/main/java/net/codestory/http/types/ContentTypes.java
+++ b/src/main/java/net/codestory/http/types/ContentTypes.java
@@ -57,7 +57,7 @@ public class ContentTypes {
       case ".mjs":
       case ".coffee":
       case ".litcoffee":
-        return "application/javascript;charset=UTF-8";
+        return "text/javascript;charset=UTF-8";
       case ".zip":
         return "application/zip";
       case ".gz":

--- a/src/test/java/net/codestory/http/types/ContentTypesTest.java
+++ b/src/test/java/net/codestory/http/types/ContentTypesTest.java
@@ -46,6 +46,8 @@ public class ContentTypesTest {
     assertThat(get("font.woff")).isEqualTo("application/x-font-woff");
     assertThat(get("font.woff2")).isEqualTo("application/x-font-woff");
     assertThat(get("script.js")).isEqualTo("application/javascript;charset=UTF-8");
+    assertThat(get("script.mjs")).isEqualTo("application/javascript;charset=UTF-8");
+    assertThat(get("script.cjs")).isEqualTo("application/javascript;charset=UTF-8");
     assertThat(get("script.coffee")).isEqualTo("application/javascript;charset=UTF-8");
     assertThat(get("script.litcoffee")).isEqualTo("application/javascript;charset=UTF-8");
     assertThat(get("favicon.ico")).isEqualTo("image/x-icon");

--- a/src/test/java/net/codestory/http/types/ContentTypesTest.java
+++ b/src/test/java/net/codestory/http/types/ContentTypesTest.java
@@ -47,7 +47,6 @@ public class ContentTypesTest {
     assertThat(get("font.woff2")).isEqualTo("application/x-font-woff");
     assertThat(get("script.js")).isEqualTo("application/javascript;charset=UTF-8");
     assertThat(get("script.mjs")).isEqualTo("application/javascript;charset=UTF-8");
-    assertThat(get("script.cjs")).isEqualTo("application/javascript;charset=UTF-8");
     assertThat(get("script.coffee")).isEqualTo("application/javascript;charset=UTF-8");
     assertThat(get("script.litcoffee")).isEqualTo("application/javascript;charset=UTF-8");
     assertThat(get("favicon.ico")).isEqualTo("image/x-icon");

--- a/src/test/java/net/codestory/http/types/ContentTypesTest.java
+++ b/src/test/java/net/codestory/http/types/ContentTypesTest.java
@@ -45,10 +45,10 @@ public class ContentTypesTest {
     assertThat(get("font.ttf")).isEqualTo("application/x-font-ttf");
     assertThat(get("font.woff")).isEqualTo("application/x-font-woff");
     assertThat(get("font.woff2")).isEqualTo("application/x-font-woff");
-    assertThat(get("script.js")).isEqualTo("application/javascript;charset=UTF-8");
-    assertThat(get("script.mjs")).isEqualTo("application/javascript;charset=UTF-8");
-    assertThat(get("script.coffee")).isEqualTo("application/javascript;charset=UTF-8");
-    assertThat(get("script.litcoffee")).isEqualTo("application/javascript;charset=UTF-8");
+    assertThat(get("script.js")).isEqualTo("text/javascript;charset=UTF-8");
+    assertThat(get("script.mjs")).isEqualTo("text/javascript;charset=UTF-8");
+    assertThat(get("script.coffee")).isEqualTo("text/javascript;charset=UTF-8");
+    assertThat(get("script.litcoffee")).isEqualTo("text/javascript;charset=UTF-8");
     assertThat(get("favicon.ico")).isEqualTo("image/x-icon");
     assertThat(get("video.mp4")).isEqualTo("video/mp4");
     assertThat(get("video.mp3")).isEqualTo("audio/mpeg");


### PR DESCRIPTION
This PR adds content type support for MJS files (ECMAScript Modules) which is a valid Javascript type and must be downloaded as such. It also changes Javascript content type to "text/application" as defined in [RFC 9239](https://www.rfc-editor.org/rfc/rfc9239) standard.