### PR TITLE
Feat/gzip certain mime types

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,10 +203,12 @@ In production mode:
 - Stops looking for changes in `app` folder
 - Doesn't serve `.map` and `.source` files
 - It caches static resources as much as possible in memory
-- It activates gzip compression on every request
+- It activates gzip compression for customizable whitelisted content-types on every request.
 
 We encourage you to use production mode whenever you deploy you website in real life and *not* activate it in dev mode.
 To activate production mode, start the JVM with `-DPROD_MODE=true`.
+
+To change the whitelisted content-types for compression use `Env.withGzipTypes(String... types)`.
 
 ## Static pages
 

--- a/src/main/java/net/codestory/http/Response.java
+++ b/src/main/java/net/codestory/http/Response.java
@@ -34,6 +34,8 @@ public interface Response extends Unwrappable {
 
   void setCookie(Cookie cookie);
 
+  String getHeader(String name);
+
   default void setCookies(Iterable<Cookie> cookies) {
     cookies.forEach(this::setCookie);
   }

--- a/src/main/java/net/codestory/http/internal/SimpleResponse.java
+++ b/src/main/java/net/codestory/http/internal/SimpleResponse.java
@@ -81,6 +81,11 @@ class SimpleResponse implements Response {
   }
 
   @Override
+  public String getHeader(String name) {
+    return response.getValue(name);
+  }
+
+  @Override
   @SuppressWarnings("unchecked")
   public <T> T unwrap(Class<T> type) {
     return type.isInstance(response) ? (T) response : null;

--- a/src/main/java/net/codestory/http/logs/Logs.java
+++ b/src/main/java/net/codestory/http/logs/Logs.java
@@ -85,6 +85,8 @@ public class Logs {
     LOG.error("Unable to configure routes properly", e);
   }
 
+  public static void resetContentLength() { LOG.info("Clear Content-Length header as end-to-end compression is activated for this Content-Type");}
+
   private interface LogsImplementation {
     void info(String message);
 

--- a/src/main/java/net/codestory/http/misc/Env.java
+++ b/src/main/java/net/codestory/http/misc/Env.java
@@ -22,12 +22,21 @@ import java.io.Serializable;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import static net.codestory.http.io.ClassPaths.classpathFolders;
 import static net.codestory.http.misc.MemoizingSupplier.memoize;
 
 public class Env implements Serializable {
+  static final Set<String> DEFAULT_GZIP_TYPES = Set.of(
+    "text/html", "text/plain", "text/css",
+    "text/javascript", "text/xml",
+    "application/json", "application/javascript",
+    "application/x-javascript", "application/xml",
+    "image/svg+xml"
+  );
+
   private final File workingDir;
   private final boolean prodMode;
   private final boolean classPath;
@@ -38,6 +47,7 @@ public class Env implements Serializable {
   private final boolean diskCache;
   private final Supplier<MasterFolderWatch> folderWatch;
   private final String appFolder;
+  private final Set<String> gzipTypes;
 
   public Env() {
     this(
@@ -49,11 +59,12 @@ public class Env implements Serializable {
       getBoolean("http.livereload.server", true),
       getBoolean("http.livereload.script", true),
       getBoolean("http.cache.disk", true),
-      get("APP_FOLDER", "app")
+      get("APP_FOLDER", "app"),
+      DEFAULT_GZIP_TYPES
     );
   }
 
-  private Env(File workingDir, boolean prodMode, boolean classPath, boolean filesystem, boolean gzip, boolean liveReloadServer, boolean injectLiveReloadScript, boolean diskCache, String appFolder) {
+  private Env(File workingDir, boolean prodMode, boolean classPath, boolean filesystem, boolean gzip, boolean liveReloadServer, boolean injectLiveReloadScript, boolean diskCache, String appFolder, Set<String> gzipTypes) {
     this.workingDir = workingDir;
     this.prodMode = prodMode;
     this.classPath = classPath;
@@ -64,54 +75,59 @@ public class Env implements Serializable {
     this.diskCache = diskCache;
     this.folderWatch = memoize(() -> new MasterFolderWatch(this));
     this.appFolder = appFolder;
+    this.gzipTypes = gzipTypes;
   }
 
   // helper factories
 
   public static Env prod() {
-    return new Env(new File("."), true, true, true, true, false, false, true, "app");
+    return new Env(new File("."), true, true, true, true, false, false, true, "app", DEFAULT_GZIP_TYPES);
   }
 
   public static Env dev() {
-    return new Env(new File("."), false, true, true, false, true, true, true, "app");
+    return new Env(new File("."), false, true, true, false, true, true, true, "app", DEFAULT_GZIP_TYPES);
   }
 
-  public static Env dev(File workingDir) { return new Env(workingDir, false, false, true, false, true, true, true, "app");}
+  public static Env dev(File workingDir) { return new Env(workingDir, false, false, true, false, true, true, true, "app", DEFAULT_GZIP_TYPES);}
 
   public Env withWorkingDir(File newWorkingDir) {
-    return new Env(newWorkingDir, prodMode, classPath, filesystem, gzip, liveReloadServer, injectLiveReloadScript, diskCache, appFolder);
+    return new Env(newWorkingDir, prodMode, classPath, filesystem, gzip, liveReloadServer, injectLiveReloadScript, diskCache, appFolder, gzipTypes);
   }
 
   public Env withProdMode(boolean newProdMode) {
-    return new Env(workingDir, newProdMode, classPath, filesystem, gzip, liveReloadServer, injectLiveReloadScript, diskCache, appFolder);
+    return new Env(workingDir, newProdMode, classPath, filesystem, gzip, liveReloadServer, injectLiveReloadScript, diskCache, appFolder, gzipTypes);
   }
 
   public Env withClassPath(boolean shouldScanCassPath) {
-    return new Env(workingDir, prodMode, shouldScanCassPath, filesystem, gzip, liveReloadServer, injectLiveReloadScript, diskCache, appFolder);
+    return new Env(workingDir, prodMode, shouldScanCassPath, filesystem, gzip, liveReloadServer, injectLiveReloadScript, diskCache, appFolder, gzipTypes);
   }
 
   public Env withFilesystem(boolean shouldScanFilesystem) {
-    return new Env(workingDir, prodMode, classPath, shouldScanFilesystem, gzip, liveReloadServer, injectLiveReloadScript, diskCache, appFolder);
+    return new Env(workingDir, prodMode, classPath, shouldScanFilesystem, gzip, liveReloadServer, injectLiveReloadScript, diskCache, appFolder, gzipTypes);
   }
 
   public Env withGzip(boolean shouldGzipResponse) {
-    return new Env(workingDir, prodMode, classPath, filesystem, shouldGzipResponse, liveReloadServer, injectLiveReloadScript, diskCache, appFolder);
+    return new Env(workingDir, prodMode, classPath, filesystem, shouldGzipResponse, liveReloadServer, injectLiveReloadScript, diskCache, appFolder, gzipTypes);
+  }
+
+  public Env withGzipTypes(String... types) {
+    return new Env(workingDir, prodMode, classPath, filesystem, gzip, liveReloadServer, injectLiveReloadScript, diskCache, appFolder, Set.of(types));
   }
 
   public Env withLiveReloadServer(boolean shouldStartLiveReloadServer) {
-    return new Env(workingDir, prodMode, classPath, filesystem, gzip, shouldStartLiveReloadServer, injectLiveReloadScript, diskCache, appFolder);
+    return new Env(workingDir, prodMode, classPath, filesystem, gzip, shouldStartLiveReloadServer, injectLiveReloadScript, diskCache, appFolder, gzipTypes);
   }
 
   public Env withInjectLiveReloadScript(boolean shouldInjectLiveReloadScript) {
-    return new Env(workingDir, prodMode, classPath, filesystem, gzip, liveReloadServer, shouldInjectLiveReloadScript, diskCache, appFolder);
+    return new Env(workingDir, prodMode, classPath, filesystem, gzip, liveReloadServer, shouldInjectLiveReloadScript, diskCache, appFolder, gzipTypes);
   }
 
   public Env withDiskCache(boolean shouldUseDiskCache) {
-    return new Env(workingDir, prodMode, classPath, filesystem, gzip, liveReloadServer, injectLiveReloadScript, shouldUseDiskCache, appFolder);
+    return new Env(workingDir, prodMode, classPath, filesystem, gzip, liveReloadServer, injectLiveReloadScript, shouldUseDiskCache, appFolder, gzipTypes);
   }
 
   public Env withAppFolder(String shouldAppFolder) {
-    return new Env(workingDir, prodMode, classPath, filesystem, gzip, liveReloadServer, injectLiveReloadScript, diskCache, shouldAppFolder);
+    return new Env(workingDir, prodMode, classPath, filesystem, gzip, liveReloadServer, injectLiveReloadScript, diskCache, shouldAppFolder, gzipTypes);
   }
 
   //
@@ -156,8 +172,15 @@ public class Env implements Serializable {
   }
 
   public boolean gzip() {
-
     return gzip;
+  }
+
+  public boolean isGzipableContentType(String contentType) {
+    if (contentType == null) {
+      return false;
+    }
+    String baseType = contentType.split(";")[0].trim();
+    return gzipTypes.stream().anyMatch(baseType::startsWith);
   }
 
   public boolean liveReloadServer() {

--- a/src/main/java/net/codestory/http/payload/PayloadWriter.java
+++ b/src/main/java/net/codestory/http/payload/PayloadWriter.java
@@ -78,6 +78,7 @@ public class PayloadWriter {
   protected final Site site;
   protected final Resources resources;
   protected final CompilerFacade compilers;
+  private String responseContentType;
 
   public PayloadWriter(Request request, Response response, Env env, Site site, Resources resources, CompilerFacade compilers) {
     this.request = request;
@@ -179,6 +180,7 @@ public class PayloadWriter {
     String uri = request.uri();
 
     String contentTypeHeader = (contentType != null) ? contentType : getContentType(content, uri);
+    responseContentType = contentTypeHeader;
     response.setHeader(CONTENT_TYPE, contentTypeHeader);
     response.setStatus(code);
 
@@ -311,7 +313,7 @@ public class PayloadWriter {
   }
 
   protected boolean shouldGzip() {
-    return env.gzip() && env.prodMode() && request.header(ACCEPT_ENCODING, "").contains(GZIP);
+    return env.gzip() && env.prodMode() && request.header(ACCEPT_ENCODING, "").contains(GZIP) && env.isGzipableContentType(responseContentType);
   }
 
   protected boolean shouldIgnoreError(IOException e) {

--- a/src/main/java/net/codestory/http/payload/PayloadWriter.java
+++ b/src/main/java/net/codestory/http/payload/PayloadWriter.java
@@ -22,6 +22,7 @@ import static net.codestory.http.constants.Headers.ACCEPT_ENCODING;
 import static net.codestory.http.constants.Headers.CACHE_CONTROL;
 import static net.codestory.http.constants.Headers.CONNECTION;
 import static net.codestory.http.constants.Headers.CONTENT_ENCODING;
+import static net.codestory.http.constants.Headers.CONTENT_LENGTH;
 import static net.codestory.http.constants.Headers.CONTENT_TYPE;
 import static net.codestory.http.constants.Headers.ETAG;
 import static net.codestory.http.constants.Headers.IF_MODIFIED_SINCE;
@@ -35,6 +36,7 @@ import static net.codestory.http.constants.HttpStatus.NO_CONTENT;
 import static net.codestory.http.constants.HttpStatus.OK;
 import static net.codestory.http.constants.Methods.HEAD;
 import static net.codestory.http.io.Strings.stripQuotes;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -279,7 +281,7 @@ public class PayloadWriter {
     try {
       if (shouldGzip()) {
         response.setHeader(CONTENT_ENCODING, GZIP);
-
+        resetContentLengthHeaderSetBeforeCompression();
         GZIPOutputStream gzip = new GZIPOutputStream(response.outputStream());
         stream.write(gzip);
         gzip.finish();
@@ -297,7 +299,7 @@ public class PayloadWriter {
     try {
       if (shouldGzip()) {
         response.setHeader(CONTENT_ENCODING, GZIP);
-
+        resetContentLengthHeaderSetBeforeCompression();
         GZIPOutputStream gzip = new GZIPOutputStream(response.outputStream());
         gzip.write(data);
         gzip.finish();
@@ -313,7 +315,8 @@ public class PayloadWriter {
   }
 
   protected boolean shouldGzip() {
-    return env.gzip() && env.prodMode() && request.header(ACCEPT_ENCODING, "").contains(GZIP) && env.isGzipableContentType(responseContentType);
+    return env.gzip() && env.prodMode() && request.header(ACCEPT_ENCODING, "").contains(GZIP) && 
+            env.isGzipableContentType(responseContentType);
   }
 
   protected boolean shouldIgnoreError(IOException e) {
@@ -512,5 +515,12 @@ public class PayloadWriter {
 
   protected Payload errorAsJson(int errorCode, Throwable e) {
     return new Payload("application/json;charset=UTF-8", new ErrorPayload(e), errorCode);
+  }
+
+  private void resetContentLengthHeaderSetBeforeCompression() {
+    if(!isEmpty(response.getHeader(CONTENT_LENGTH))) {
+      Logs.resetContentLength();
+      response.setHeader(CONTENT_LENGTH, null);
+    }
   }
 }

--- a/src/test/java/net/codestory/http/misc/EnvTest.java
+++ b/src/test/java/net/codestory/http/misc/EnvTest.java
@@ -194,4 +194,26 @@ public class EnvTest {
     assertThat(env.liveReloadServer()).isFalse();
     assertThat(env.diskCache()).isFalse();
   }
+
+  @Test
+  public void gzipable_content_type_defaults() {
+    Env env = Env.prod();
+
+    assertThat(env.isGzipableContentType("text/html")).isTrue();
+    assertThat(env.isGzipableContentType("text/html;charset=UTF-8")).isTrue();
+    assertThat(env.isGzipableContentType("application/json")).isTrue();
+    assertThat(env.isGzipableContentType("application/json;charset=UTF-8")).isTrue();
+    assertThat(env.isGzipableContentType("application/octet-stream")).isFalse();
+    assertThat(env.isGzipableContentType("application/zip")).isFalse();
+    assertThat(env.isGzipableContentType(null)).isFalse();
+  }
+
+  @Test
+  public void with_gzip_types_overrides_defaults() {
+    Env env = Env.prod().withGzipTypes("text/plain");
+
+    assertThat(env.isGzipableContentType("text/plain")).isTrue();
+    assertThat(env.isGzipableContentType("text/html")).isFalse();
+    assertThat(env.isGzipableContentType("application/json")).isFalse();
+  }
 }

--- a/src/test/java/net/codestory/http/payload/PayloadWriterTest.java
+++ b/src/test/java/net/codestory/http/payload/PayloadWriterTest.java
@@ -20,9 +20,11 @@ import net.codestory.http.Cookies;
 import net.codestory.http.Request;
 import net.codestory.http.Response;
 import net.codestory.http.compilers.CompilerFacade;
+import net.codestory.http.constants.Encodings;
 import net.codestory.http.io.Resources;
 import net.codestory.http.misc.Env;
 import net.codestory.http.templating.Site;
+import org.apache.http.entity.ContentType;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -231,6 +233,35 @@ public class PayloadWriterTest {
     verify(response).setStatus(OK);
     verify(response, never()).setContentLength(anyInt());
     verify(response, never()).outputStream();
+  }
+
+  @Test
+  public void ensureContentLengthIsResetUponCompression() throws IOException {
+    //Activate gzip compression
+    Env prodEnv = Env.prod();
+    when(request.header(ACCEPT_ENCODING, "")).thenReturn(Encodings.GZIP);
+    when(response.getHeader(CONTENT_LENGTH)).thenReturn("1024");
+    PayloadWriter compressionWriter = new PayloadWriter(request, response, prodEnv, site, resources, compilerFacade);
+    Payload payload = new Payload(ContentType.TEXT_PLAIN.getMimeType(), "Hello"); //"text/plain" is part of the default whitelist for Gzip
+
+    compressionWriter.writeAndClose(payload);
+
+    verify(response, times(1)).setHeader(CONTENT_LENGTH, null);
+  }
+
+  @Test
+  public void ensureContentLengthIsResetUponCompressionForStreams() throws IOException {
+
+    //Activate gzip compression for stream
+    Env prodEnv = Env.prod().withGzipTypes("application/octet-stream");
+    when(request.header(ACCEPT_ENCODING, "")).thenReturn(Encodings.GZIP);
+    when(response.getHeader(CONTENT_LENGTH)).thenReturn("1024");
+    PayloadWriter compressionWriter = new PayloadWriter(request, response, prodEnv, site, resources, compilerFacade);
+    Payload payload = new Payload( new ByteArrayInputStream("Hello".getBytes(UTF_8)));
+
+    compressionWriter.writeAndClose(payload);
+
+    verify(response, times(1)).setHeader(CONTENT_LENGTH, null);
   }
 
   static class Person {


### PR DESCRIPTION
This PR adds a configurable whitelist of `Content-Type` for which end-to-end gzip compression is used to transmit response content. The whitelist can be configured using `Env.withGzipTypes(String... types)`. By default the whitelist contains the following entries :
```java
    "text/html", "text/plain", "text/css",
    "text/javascript", "text/xml",
    "application/json", "application/javascript",
    "application/x-javascript", "application/xml",
    "image/svg+xml"
```

The goal is to avoid doing double compression which uses CPU for very little size reduction.

The PR also removes the header `Content-Length` when using compression if it has been set by the user to avoid erroneous value as recommended by [RFC 9110 section 8.6](https://datatracker.ietf.org/doc/html/rfc9110#name-content-length)
